### PR TITLE
Add protected admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Bac Ciel PMF est un site web développé en TypeScript, Tailwind et Firebase pou
 - Création et modification des cours
 - Ajout et suppression de documents
 - Suivi des progrès des élèves
+- Le panneau `/admin` est réservé aux administrateurs et présente quelques fonctionnalités de gestion.
 
 ## Panneau d'élève:
 

--- a/src/config/admin-config.ts
+++ b/src/config/admin-config.ts
@@ -1,0 +1,3 @@
+export const ADMIN_EMAILS = [
+  "admin@example.com"
+];

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,87 @@
+import { Seo } from "@/ui/components/SEO/seo";
+import { Layout } from "@/ui/components/layout/layout";
+import { Container } from "@/ui/components/container/container";
+import { Typography } from "@/ui/design-system/typography/typography";
+import { Box } from "@/ui/design-system/box/box";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "@/config/firebase-config";
+import { ADMIN_EMAILS } from "@/config/admin-config";
+
+export default function AdminPanel() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      const isAdmin = !!user && ADMIN_EMAILS.includes(user.email ?? "");
+      setAuthorized(isAdmin);
+      setLoading(false);
+      if (!isAdmin) {
+        router.replace("/");
+      }
+    });
+    return () => unsubscribe();
+  }, [router]);
+
+  if (loading) {
+    return (
+      <Layout>
+        <Container className="py-10">
+          <Typography variant="h1">Chargement...</Typography>
+        </Container>
+      </Layout>
+    );
+  }
+
+  if (!authorized) {
+    return null;
+  }
+
+  const features = [
+    {
+      title: "Gestion des comptes",
+      description: "Créer, modifier et supprimer les utilisateurs.",
+    },
+    {
+      title: "Gestion des cours",
+      description: "Ajouter ou mettre à jour les programmes de cours.",
+    },
+    {
+      title: "Documents",
+      description: "Envoyer ou retirer des documents pédagogiques.",
+    },
+    {
+      title: "Suivi des élèves",
+      description: "Consulter la progression des apprenants.",
+    },
+  ];
+
+  return (
+    <>
+      <Seo title="Panneau d'administration" description="Gestion du contenu" />
+      <Layout>
+        <Container className="py-10 space-y-4">
+          <Typography variant="h1">Panneau d&apos;administration</Typography>
+          <Typography variant="body-base">
+            Gérez le contenu et les utilisateurs du site.
+          </Typography>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {features.map((feature) => (
+              <Box key={feature.title}>
+                <Typography variant="h3" component="h2" className="mb-2">
+                  {feature.title}
+                </Typography>
+                <Typography variant="body-base" theme="gray">
+                  {feature.description}
+                </Typography>
+              </Box>
+            ))}
+          </div>
+        </Container>
+      </Layout>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- restrict `/admin` route to admin users based on email
- show placeholder dashboard sections for account, course, document and progress management
- document admin-only panel in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401be1b8ec8321bef75c53e3c84a77